### PR TITLE
feat: Add gateway heartbeat activation setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Common to all modules:
 **Optional:**
 
 * `JVM_COMMON_BUILDPACK`: (optional) by default `https://buildpacks-repository.s3.eu-central-1.amazonaws.com/jvm-common.tar.xz`
+* `GRAVITEE_HEARTBEAT_ENABLED`: (optional) by default `false`, configure wether or not the gateway should report its status to the REST API
 
 ### graviteeio-portal-ui
 

--- a/gravitee/graviteeio-gateway/config/gravitee.yml.erb
+++ b/gravitee/graviteeio-gateway/config/gravitee.yml.erb
@@ -248,10 +248,14 @@ services:
 
 # heartbeat
   heartbeat:
-    enabled: false
+<% if @heartbeat_enabled %>
+    enabled: true
 #    delay: 5000
 #    unit: MILLISECONDS
 #    storeSystemProperties: true
+<% else %>
+    enabled: false
+<% end %>
 
 #handlers:
 #  request:

--- a/gravitee/graviteeio-gateway/scripts/config.rb
+++ b/gravitee/graviteeio-gateway/scripts/config.rb
@@ -19,6 +19,9 @@ end
 @elasticsearch_url = URI(ENV["ELASTICSEARCH_URL"])
 @mongo_url = ENV["MONGO_URL"]
 
+# Optional configuration to enable gateway heartbeat
+@heartbeat_enabled = ENV.fetch("GRAVITEE_HEARTBEAT_ENABLED", "false") == "true"
+
 gravitee_config_template = "#{config_dir}/gravitee.yml.erb"
 gravitee_config_install = "#{install_dir}/config/gravitee.yml"
 if File.exists? gravitee_config_template


### PR DESCRIPTION
🦄 Problem
Gateway does not report its status to the REST API, and is not visible in the management interface under `$MANAGEMENT_UI_URL/#!/instances/`

🤖 Solution
Allow gateway heartbeat to be enabled

💯 Tests

- Launch the gateway as is, gateway heartbeat should be disabled and it should not appear in the management UI
- Set `GRAVITEE_HEARTBEAT_ENABLED` to `false` and launch the gateway, gateway heartbeat should be disabled and it should not appear in the management UI
- Set `GRAVITEE_HEARTBEAT_ENABLED` to `true` and launch the gateway, gateway heartbeat should be enabled and it should appear in the management UI