### PR TITLE
bug: fix themes import in management UI

### DIFF
--- a/gravitee/graviteeio-management-ui/scripts/config.sh
+++ b/gravitee/graviteeio-management-ui/scripts/config.sh
@@ -9,6 +9,6 @@ sed "s#MANAGEMENT_API_URL#${MANAGEMENT_API_URL}#" "${CONFIG_DIR}/${CONSTANTS_FIL
 
 if [ -d "$CONFIG_DIR/themes" ] ; then
   echo "-----> Copying theme assets…"
-  cp -r "${CONFIG_DIR}/themes" "${INSTALL_DIR}/themes"
+  cp -r "${CONFIG_DIR}"/themes/* "${INSTALL_DIR}/themes/"
 fi
 


### PR DESCRIPTION
🦄 Problem

Management UI does not copy themes assets correctly. 
A png added in `config/themes/assets/ui-logo.png` is not copied to `config/themes/assets/ui-logo.png` but instead to `config/themes/themes/assets/ui-logo.png`

🤖 Solution

Fix the cp command arguments in config script to merge all files and subfolders from the `config/themes`directory into the management UI themes directory.

💯 Tests

Either one of the two following methods is fine :

Front : 
1) Add a custom file in `config/themes/default-theme.json` and  `config/themes/assets/ui-logo.png`.
2) Launch the management UI.
3) Ensure that the logo and the theme of Gravitee are now changed

Container one-off :
1) Add a custom file in `config/themes/default-theme.json` and  `config/themes/assets/ui-logo.png`.
2) Run `./scripts/config.sh`
3) Run `ls /app/graviteeio-management-ui/themes/default-theme.json /app/graviteeio-management-ui/themes/assets/ui-logo.png` and ensure the file are present.
