### PR TITLE
bug: fix file copying in REST API configuration

### DIFF
--- a/gravitee/graviteeio-rest-api/scripts/config.rb
+++ b/gravitee/graviteeio-rest-api/scripts/config.rb
@@ -3,6 +3,7 @@
 require 'uri'
 require 'erb'
 require 'bcrypt'
+require 'fileutils'
 
 install_dir="#{ENV["HOME"]}/#{ENV["GRAVITEE_MODULE"]}"
 config_dir="#{ENV["HOME"]}/config"


### PR DESCRIPTION
🦄 Problem

REST API does not copy themes and templates at startup.
A png added in `config/templates/images/logo-custom.png` is not copied to `templates/images/logo-custom.png`.
The container start with the following warning :

```
-----> Copying themes…
Did you mean?  FileTest
/app/scripts/config.rb:36:in `<main>': uninitialized constant FileUtils (NameError)
```

🤖 Solution

Import FileUtils

💯 Tests

Either one of the two following methods is fine :

Front :

1) Add a custom file in `config/templates/images/logo-custom.png`.
2) Launch the REST API.
3) Ensure that the logo is available in Gravitee.

Container one-off :

1) Add a custom file in `config/templates/images/logo-custom.png`.
2) Run `./scripts/config.rb`
3) Run `ls /app/graviteeio-rest-api/templates/images/logo-custom.png` and ensure the file is present.