### PR TITLE
Rename variable MANAGEMENT_API_URL to API_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Common to all modules:
 
 **Required:**
 
-* `MANAGEMENT_API_URL`: URL to the REST API application, example: `https://my-gravitee-rest-api.osc-fr1.scalingo.io`
+* `API_URL`: URL to the REST API application, example: `https://my-gravitee-rest-api.osc-fr1.scalingo.io` (old name: `MANAGEMENT_API_URL`)
 
 **Optional:**
 
@@ -116,7 +116,7 @@ Common to all modules:
 
 **Required:**
 
-* `MANAGEMENT_API_URL`: URL to the REST API application, example: `https://my-gravitee-rest-api.osc-fr1.scalingo.io`
+* `API_URL`: URL to the REST API application, example: `https://my-gravitee-rest-api.osc-fr1.scalingo.io` (old name: `MANAGEMENT_API_URL`)
 
 **Optional:**
 

--- a/gravitee/graviteeio-management-ui/config/constants.json
+++ b/gravitee/graviteeio-management-ui/config/constants.json
@@ -1,3 +1,3 @@
 {
-  "baseURL": "MANAGEMENT_API_URL/management/organizations/DEFAULT/environments/DEFAULT"
+  "baseURL": "API_URL/management/organizations/DEFAULT/environments/DEFAULT"
 }

--- a/gravitee/graviteeio-management-ui/sample.env
+++ b/gravitee/graviteeio-management-ui/sample.env
@@ -3,4 +3,4 @@ GRAVITEE_MODULE=graviteeio-management-ui
 # folder name (used by buildpack to determine the module to install)
 PROJECT_DIR=graviteeio-management-ui
 # API url
-MANAGEMENT_API_URL=
+API_URL=

--- a/gravitee/graviteeio-management-ui/scripts/config.sh
+++ b/gravitee/graviteeio-management-ui/scripts/config.sh
@@ -5,7 +5,9 @@ CONFIG_DIR=${HOME}/config
 
 CONSTANTS_FILE=constants.json
 
-sed "s#MANAGEMENT_API_URL#${MANAGEMENT_API_URL}#" "${CONFIG_DIR}/${CONSTANTS_FILE}" > ${INSTALL_DIR}/${CONSTANTS_FILE}
+API_URL="${API_URL:-$MANAGEMENT_API_URL}"
+
+sed "s#API_URL#${API_URL}#" "${CONFIG_DIR}/${CONSTANTS_FILE}" > ${INSTALL_DIR}/${CONSTANTS_FILE}
 
 if [ -d "$CONFIG_DIR/themes" ] ; then
   echo "-----> Copying theme assets…"

--- a/gravitee/graviteeio-portal-ui/config/config.json
+++ b/gravitee/graviteeio-portal-ui/config/config.json
@@ -1,5 +1,5 @@
 {
-  "baseURL": "MANAGEMENT_API_URL/portal/environments/DEFAULT",
+  "baseURL": "API_URL/portal/environments/DEFAULT",
   "loaderURL": "assets/images/gravitee-loader.gif",
   "pagination": {
     "size": {

--- a/gravitee/graviteeio-portal-ui/sample.env
+++ b/gravitee/graviteeio-portal-ui/sample.env
@@ -3,4 +3,4 @@ GRAVITEE_MODULE=graviteeio-portal-ui
 # folder name (used by buildpack to determine the module to install)
 PROJECT_DIR=graviteeio-portal-ui
 # API url
-MANAGEMENT_API_URL=
+API_URL=

--- a/gravitee/graviteeio-portal-ui/scripts/config.sh
+++ b/gravitee/graviteeio-portal-ui/scripts/config.sh
@@ -4,4 +4,6 @@ INSTALL_DIR="/${HOME}/${GRAVITEE_MODULE}"
 CONFIG_DIR=/${HOME}/config
 CONFIG_FILE="${CONFIG_DIR}/config.json"
 
-cat $CONFIG_FILE | sed "s#MANAGEMENT_API_URL#${MANAGEMENT_API_URL}#" > ${INSTALL_DIR}/assets/config.json
+API_URL="${API_URL:-$MANAGEMENT_API_URL}"
+
+cat $CONFIG_FILE | sed "s#API_URL#${API_URL}#" > ${INSTALL_DIR}/assets/config.json


### PR DESCRIPTION
It also keep the compatibility with the old name.

The old name could be confused about the management UI.