### PR TITLE
chore: Disable file logging in gateway and restore default configuration

### DIFF
--- a/gravitee/graviteeio-gateway/config/logback.xml
+++ b/gravitee/graviteeio-gateway/config/logback.xml
@@ -27,10 +27,10 @@
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${gravitee.home}/logs/gravitee.log</file>
+        <file>${gravitee.gateway.log.dir}/gravitee.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover -->
-            <fileNamePattern>${gravitee.home}/logs/gravitee_%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${gravitee.gateway.log.dir}/gravitee_%d{yyyy-MM-dd}.log</fileNamePattern>
 
             <!-- keep 30 days' worth of history -->
             <maxHistory>30</maxHistory>
@@ -49,9 +49,14 @@
         <appender-ref ref="STDOUT" />
     </appender>
 
+    <logger name="io.gravitee" level="INFO" />
+    <logger name="org.reflections" level="WARN" />
+    <logger name="org.springframework" level="WARN" />
+    <logger name="org.eclipse.jetty" level="WARN" />
+
     <!-- Strictly speaking, the level attribute is not necessary since -->
     <!-- the level of the root level is set to DEBUG by default.       -->
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="async-console" />
         <appender-ref ref="async-file" />
     </root>

--- a/gravitee/graviteeio-gateway/config/logback.xml
+++ b/gravitee/graviteeio-gateway/config/logback.xml
@@ -26,25 +26,6 @@
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${gravitee.gateway.log.dir}/gravitee.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <!-- daily rollover -->
-            <fileNamePattern>${gravitee.gateway.log.dir}/gravitee_%d{yyyy-MM-dd}.log</fileNamePattern>
-
-            <!-- keep 30 days' worth of history -->
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{api}] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="async-file" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="FILE" />
-    </appender>
-
     <appender name="async-console" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="STDOUT" />
     </appender>
@@ -58,7 +39,6 @@
     <!-- the level of the root level is set to DEBUG by default.       -->
     <root level="WARN">
         <appender-ref ref="async-console" />
-        <appender-ref ref="async-file" />
     </root>
 
 </configuration>

--- a/gravitee/graviteeio-gateway/config/logback.xml
+++ b/gravitee/graviteeio-gateway/config/logback.xml
@@ -49,14 +49,9 @@
         <appender-ref ref="STDOUT" />
     </appender>
 
-    <logger name="io.gravitee" level="DEBUG" />
-    <logger name="org.reflections" level="WARN" />
-    <logger name="org.springframework" level="WARN" />
-    <logger name="org.eclipse.jetty" level="WARN" />
-
     <!-- Strictly speaking, the level attribute is not necessary since -->
     <!-- the level of the root level is set to DEBUG by default.       -->
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="async-console" />
         <appender-ref ref="async-file" />
     </root>

--- a/gravitee/graviteeio-gateway/scripts/config.rb
+++ b/gravitee/graviteeio-gateway/scripts/config.rb
@@ -2,6 +2,7 @@
 #
 require 'uri'
 require 'erb'
+require 'fileutils'
 
 install_dir="#{ENV["HOME"]}/#{ENV["GRAVITEE_MODULE"]}"
 config_dir="#{ENV["HOME"]}/config"


### PR DESCRIPTION
🦄 Problem

Gateway is configured to log in the  `/logs/gravitee%d{yyyy-MM-dd}.log` files for up to 30 days, but those logs cannot be accessed.
Gateway is configured to log in `DEBUG` by default.

🤖 Solution

Disable file logging in logback and restore configuration from [Gravitee gateway logback](https://github.com/gravitee-io/gravitee-gateway/blob/master/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/logback.xml)

💯 Tests

Try to run the application in a one-off and ensure that no gateway logs are written to files.
Ensure that there is no more logs in DEBUG.